### PR TITLE
fix: typescript buildInfo

### DIFF
--- a/packages/typescript/src/getProgram.ts
+++ b/packages/typescript/src/getProgram.ts
@@ -28,6 +28,11 @@ export function getProgram(
 			}
 			return target[property];
 		},
+		set: (_target, property, newValue) => {
+			const program = getProgram();
+			(program as any)[property] = newValue;
+			return true;
+		},
 	});
 
 	function getProgram() {


### PR DESCRIPTION
fix: https://github.com/johnsoncodehk/volar/issues/2138

getProgramBuildInfo is set to program in createBuilderProgram

https://github.com/microsoft/TypeScript/blob/v4.9.4/src/compiler/builder.ts#L1147

but with proxy don't have setter function it won't work